### PR TITLE
Invert some icons, match storybook styles

### DIFF
--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -10,7 +10,7 @@
                 <mat-divider></mat-divider>
                 <mat-nav-list style="padding-top: 0">
                     <pxb-info-list-item divider="full" chevron="true">
-                        <mat-icon pxb-icon>feedback</mat-icon>
+                        <mat-icon pxb-icon class="invert-rtl">feedback</mat-icon>
                         <div pxb-title>Basement Sensor</div>
                         <div pxb-subtitle>Dwyer RJ382</div>
                     </pxb-info-list-item>
@@ -103,16 +103,16 @@
         >
             <mat-icon pxb-action-items>more_vert</mat-icon>
             <mat-list pxb-body>
-                <pxb-info-list-item dense="true" [style.color]="colors.red[500]" class="card-body-item">
-                    <div pxb-title>1 Alarm</div>
-                    <mat-icon pxb-icon>notifications</mat-icon>
+                <pxb-info-list-item dense="true" class="card-body-item">
+                    <div pxb-title [style.color]="colors.red[500]">1 Alarm</div>
+                    <mat-icon pxb-icon [style.color]="colors.red[500]">notifications</mat-icon>
                 </pxb-info-list-item>
                 <pxb-info-list-item dense="true" [style.color]="colors.blue[500]" class="card-body-item">
-                    <div pxb-title>1 Event</div>
-                    <mat-icon pxb-icon>list_alt</mat-icon>
+                    <div pxb-title [style.color]="colors.blue[500]">1 Event</div>
+                    <mat-icon pxb-icon [style.color]="colors.blue[500]" class="invert-rtl">list_alt</mat-icon>
                 </pxb-info-list-item>
                 <pxb-info-list-item dense="true" class="card-body-item">
-                    <div pxb-title>Online</div>
+                    <div pxb-title style="font-weight: 400">Online</div>
                     <mat-icon pxb-icon>cloud</mat-icon>
                 </pxb-info-list-item>
             </mat-list>
@@ -125,7 +125,7 @@
                 </pxb-hero>
             </pxb-hero-banner>
             <pxb-info-list-item hidePadding="true" dense="true" pxb-action-row mat-ripple>
-                <div pxb-title>More</div>
+                <div pxb-title>View Location</div>
                 <mat-icon mat-list-icon pxb-right-content class="scorecard-chevron">chevron_right</mat-icon>
             </pxb-info-list-item>
         </pxb-score-card>
@@ -141,27 +141,19 @@
             <mat-icon pxb-action-items>more_vert</mat-icon>
             <mat-list pxb-body>
                 <pxb-info-list-item dense="true" class="card-body-item">
-                    <div pxb-title>0 Alarms</div>
+                    <div pxb-title style="font-weight: 400">0 Alarms</div>
                     <mat-icon pxb-icon>notifications</mat-icon>
                 </pxb-info-list-item>
-                <pxb-info-list-item dense="true" [style.color]="colors.blue[500]" class="card-body-item">
-                    <div pxb-title>1 Event</div>
-                    <mat-icon pxb-icon>list_alt</mat-icon>
+                <pxb-info-list-item dense="true" class="card-body-item">
+                    <div pxb-title [style.color]="colors.blue[500]">1 Event</div>
+                    <mat-icon pxb-icon [style.color]="colors.blue[500]" class="invert-rtl">list_alt</mat-icon>
                 </pxb-info-list-item>
                 <pxb-info-list-item dense="true" class="card-body-item">
-                    <div pxb-title>Online</div>
+                    <div pxb-title style="font-weight: 400">Online</div>
                     <mat-icon pxb-icon>cloud</mat-icon>
                 </pxb-info-list-item>
             </mat-list>
-            <pxb-hero
-                pxb-badge
-                label="Health"
-                value="98"
-                units="%"
-                [iconBackgroundColor]="colors.white[50]"
-                style="cursor: pointer"
-                [iconSize]="72"
-            >
+            <pxb-hero pxb-badge label="Health" value="98" units="%" [iconSize]="72">
                 <mat-icon svgIcon="px-icons:grade_a" pxb-primary [style.color]="colors.green[500]"></mat-icon>
             </pxb-hero>
             <pxb-info-list-item hidePadding="true" dense="true" pxb-action-row mat-ripple>
@@ -184,7 +176,7 @@
                     <pxb-hero label="Load">
                         <pie-progress class="progress-icon" percent="65" size="36" pxb-primary></pie-progress>
                         <pxb-channel-value value="65" units="%">
-                            <mat-icon [style.color]="colors.red['500']">trending_up</mat-icon>
+                            <mat-icon [style.color]="colors.red['500']" class="invert-rtl">trending_up</mat-icon>
                         </pxb-channel-value>
                     </pxb-hero>
 

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -35,7 +35,7 @@
 .data-panel mat-expansion-panel,
 .data-card,
 pxb-score-card {
-    width: 450px;
+    width: 400px;
 }
 
 .data-panel {

--- a/src/app/kitchen-sink/kitchen-sink.component.html
+++ b/src/app/kitchen-sink/kitchen-sink.component.html
@@ -176,19 +176,20 @@
         <mat-card-content>
             <pxb-hero-banner>
                 <pxb-hero label="Estimated">
-                    <mat-icon pxb-primary>timer</mat-icon>
+                    <mat-icon pxb-primary class="invert-rtl">timer</mat-icon>
                     <pxb-channel-value value="1" units="h"></pxb-channel-value>
                     <pxb-channel-value value="26" units="m"></pxb-channel-value>
                 </pxb-hero>
 
                 <pxb-hero label="Battery" value="Full">
-                    <battery-progress class="progress-icon" percent="90" size="36" pxb-primary> </battery-progress>
+                    <battery-progress class="progress-icon invert-rtl" percent="90" size="36" pxb-primary>
+                    </battery-progress>
                 </pxb-hero>
 
                 <pxb-hero label="Load">
-                    <pie-progress class="progress-icon" percent="65" size="36" pxb-primary></pie-progress>
+                    <pie-progress class="progress-icon invert-rtl" percent="65" size="36" pxb-primary></pie-progress>
                     <pxb-channel-value value="65" units="%">
-                        <mat-icon [style.color]="colors.red['500']">trending_up</mat-icon>
+                        <mat-icon [style.color]="colors.red['500']" class="invert-rtl">trending_up</mat-icon>
                     </pxb-channel-value>
                 </pxb-hero>
             </pxb-hero-banner>
@@ -354,8 +355,10 @@
         <mat-card-content>
             <pxb-empty-state title="No Devices" description="Consult your local admin for details">
                 <mat-icon pxb-empty-icon>devices</mat-icon>
-                <button mat-raised-button color="primary" pxb-actions>
-                    <mat-icon>add_circle</mat-icon>
+                <button pxb-actions mat-stroked-button color="primary">
+                    <mat-icon class="empty-state-action-icon">
+                        add
+                    </mat-icon>
                     ADD DEVICE
                 </button>
             </pxb-empty-state>
@@ -417,18 +420,10 @@
                     </pxb-info-list-item>
                     <pxb-info-list-item dense="true" [style.color]="colors.blue[500]">
                         <div pxb-title>1 Event</div>
-                        <mat-icon pxb-icon>list_alt</mat-icon>
+                        <mat-icon pxb-icon class="invert-rtl">list_alt</mat-icon>
                     </pxb-info-list-item>
                 </mat-list>
-                <pxb-hero
-                    pxb-badge
-                    label="Health"
-                    value="98"
-                    units="%"
-                    [iconBackgroundColor]="colors.white[50]"
-                    style="cursor: pointer"
-                    [iconSize]="72"
-                >
+                <pxb-hero pxb-badge label="Health" value="98" units="%" [iconSize]="72">
                     <mat-icon svgIcon="px-icons:grade_a" pxb-primary [style.color]="colors.green[500]"></mat-icon>
                 </pxb-hero>
                 <pxb-info-list-item hidePadding="true" dense="true" pxb-action-row>

--- a/src/app/kitchen-sink/kitchen-sink.component.scss
+++ b/src/app/kitchen-sink/kitchen-sink.component.scss
@@ -70,3 +70,16 @@ mat-card.ng-comp-card {
         margin: 8px !important;
     }
 }
+
+/* Empty state styles */
+.pxb-empty-state .empty-state-action-icon {
+    margin-right: 8px;
+    margin-left: -4px;
+    height: 20px;
+    width: 20px;
+    font-size: 20px;
+}
+[dir='rtl'] .pxb-empty-state .empty-state-action-icon {
+    margin-right: -4px;
+    margin-left: 8px;
+}

--- a/src/app/kitchen-sink/kitchen-sink.component.ts
+++ b/src/app/kitchen-sink/kitchen-sink.component.ts
@@ -1,10 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import * as PXBColors from '@pxblue/colors';
 
 @Component({
     selector: 'app-kitchen-sink',
     templateUrl: './kitchen-sink.component.html',
     styleUrls: ['./kitchen-sink.component.scss'],
+    encapsulation: ViewEncapsulation.None,
 })
 export class KitchenSinkComponent {
     colors = PXBColors;

--- a/src/app/timeline/timeline.component.scss
+++ b/src/app/timeline/timeline.component.scss
@@ -1,5 +1,11 @@
 @import '~@pxblue/colors/palette.scss';
 
+/* RTL styles */
+[dir='rtl'] pxb-list-item-tag {
+    margin-left: 16px;
+    margin-right: 0;
+}
+
 .host {
     display: flex;
     justify-content: center;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
 @import '~@pxblue/angular-themes/theme.scss';
+@import '~@pxblue/colors/palette.scss';
 
 body {
     margin: 0;
@@ -10,4 +11,18 @@ body {
 
     // for dark theme
     // background-color: map-get($pxb-darkBlack, 100);
+}
+
+[dir='rtl'] .invert-rtl {
+    transform: scaleX(-1);
+}
+
+/* Scorecard styles */
+.pxb-blue-dark {
+    .pxb-hero-primary-wrapper {
+        background: map-get($pxb-black, 900);
+    }
+}
+.pxb-hero-primary-wrapper {
+    background: map-get($pxb-white, 50);
 }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes: https://github.com/pxblue/angular-component-library/issues/155

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- This PR addresses some missing icon inversions for RTL.  
- 



- Additional changes:
- Empty state action-icon padding
- Scorecard list item font weight changes

I know there's a separate issue for handling all other style changes.  This PR should just focus on RTL icon flipping.  

